### PR TITLE
update<q16>: update code of service to latest Angular version (v6+) in q16

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,13 +418,16 @@
     import { Injectable } from '@angular/core';
     import { Http } from '@angular/http';
 
-    @Injectable() // The Injectable decorator is required for dependency injection to work
+    @Injectable({ // The Injectable decorator is required for dependency injection to work
+      // providedIn option registers the service with a specific NgModule
+      providedIn: 'root',  // This declares the service with the root app (AppModule)
+    })
     export class RepoService{
       constructor(private http: Http){
       }
 
       fetchAll(){
-        return this.http.get('https://api.github.com/repositories').map(res => res.json());
+        return this.http.get('https://api.github.com/repositories');
       }
     }
     ```


### PR DESCRIPTION
* The old code uses map operator to convert service response to JSON format. That's angular v4 and before
* Angular 5+ does not need to convert the service response to JSON.
  And also service can be registered using providedIn option.