### PR TITLE
Updated answer to question about parameterized pipe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,13 +714,13 @@
   **[⬆ Back to Top](#table-of-contents)**
 
 29. ### What is a parameterized pipe?
-    A pipe can accept any number of optional parameters to fine-tune its output. The parameterized pipe can be created by declaring the pipe name with a colon ( : ) and then the parameter value. If the pipe accepts multiple parameters, separate the values with colons. Let's take a birthday example with a particular format(dd/mm/yyyy):
+    A pipe can accept any number of optional parameters to fine-tune its output. The parameterized pipe can be created by declaring the pipe name with a colon ( : ) and then the parameter value. If the pipe accepts multiple parameters, separate the values with colons. Let's take a birthday example with a particular format(dd/MM/yyyy):
     ```javascript
     import { Component } from '@angular/core';
 
         @Component({
           selector: 'app-birthday',
-          template: `<p>Birthday is {{ birthday | date:'dd/mm/yyyy'}}</p>` // 18/06/1987
+          template: `<p>Birthday is {{ birthday | date:'dd/MM/yyyy'}}</p>` // 18/06/1987
         })
         export class BirthdayComponent {
           birthday = new Date(1987, 6, 18);


### PR DESCRIPTION
Minor update do question 29  about parameterized pipe. Angular DatePipe handle only formats "dd/MM/yyyy" or "dd/M/yyyy" instead of "dd/mm/yyyy". Lowercase "m" is used to format time (minutes)